### PR TITLE
CI Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: node:17-slim
   golangci-lint:
     docker:
-      - image: golangci/golangci-lint:v1.42-alpine
+      - image: golangci/golangci-lint:v1.44-alpine
   golang-previous:
     docker:
       - image: golang:1.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: node:16-slim
+      - image: node:17-slim
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.42-alpine

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,9 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - containedctx
     - deadcode
+    - decorder
     - depguard
     - dogsled
     - dupl
@@ -20,7 +22,9 @@ linters:
     - gosec
     - gosimple
     - govet
+    - grouper
     - ineffassign
+    - maintidx
     - misspell
     - nakedret
     - prealloc


### PR DESCRIPTION
Bump `node` to v17, and `golangci-lint` to v1.44.